### PR TITLE
Make distrib.sh POSIX compliant

### DIFF
--- a/distrib.sh
+++ b/distrib.sh
@@ -23,10 +23,10 @@
 
 rm -rf build dist  # ??
 
-if [ "$1" == "live" ]; then
+if [ "$1" = "live" ]; then
   python setup.py sdist bdist_wheel
   twine upload dist/*
-elif [ "$1" == "test" ]; then
+elif [ "$1" = "test" ]; then
   python setup.py register -r pypitest
 else
   exit 1


### PR DESCRIPTION
This was picked up by pkgsrc:
```
===> Configuring for hypatia-0.3.3
=> Checking for portability problems in extracted files
ERROR: [check-portability.awk] => Found test ... == ...:
ERROR: [check-portability.awk] distrib.sh: if [ "$1" == "live" ]; then
ERROR: [check-portability.awk] distrib.sh: elif [ "$1" == "test" ]; then

Explanation:
===========================================================================
The "test" command, as well as the "[" command, are not required to know
the "==" operator. Only a few implementations like bash and some
versions of ksh support it.

When you run "test foo == foo" on a platform that does not support the
"==" operator, the result will be "false" instead of "true". This can
lead to unexpected behavior.

There are two ways to fix this error message. If the file that contains
the "test ==" is needed for building the package, you should create a
patch for it, replacing the "==" operator with "=". If the file is not
needed, add its name to the CHECK_PORTABILITY_SKIP variable in the
package Makefile.
===========================================================================

*** Error code 1

Stop.
make[1]: stopped in /lastkaj/pkgsrc/wip/hypatia
```